### PR TITLE
toFullHumanReadableDatetime format fix

### DIFF
--- a/client/src/helpers/timeFormatters.tsx
+++ b/client/src/helpers/timeFormatters.tsx
@@ -30,7 +30,7 @@ export function toHumanReadableDuration(date: string): string | null {
 
 export function toFullHumanReadableDatetime(dateISO: string): string | null {
   const date = toDate(parseISO(dateISO));
-  const day = format(date, 'd.mm.yy');
+  const day = format(date, 'd.MM.yy');
   const time = format(date, 'hh:mm');
   const dayPeriod = format(date, 'a');
   const timeZone = format(date, 'x');


### PR DESCRIPTION
## Description
- fixed date format for `toFullHumanReadableDatetime` function

## Screens
before
<img width="288" alt="Screenshot 2021-03-26 at 15 28 31" src="https://user-images.githubusercontent.com/990978/112631726-4b79e000-8e48-11eb-9cc7-1cbd5696907f.png">
after:
<img width="277" alt="Screenshot 2021-03-26 at 15 31 01" src="https://user-images.githubusercontent.com/990978/112631744-4f0d6700-8e48-11eb-93c3-528804dd39ad.png">
