### PR TITLE
fixed styles for SwitchField

### DIFF
--- a/client/src/components/Form/SwitchField/index.tsx
+++ b/client/src/components/Form/SwitchField/index.tsx
@@ -20,18 +20,10 @@ interface Props {
 
 const SwitchField: FC<Props> = ({ name, title, required, disabled, className, constraints: inputConstraints }) => {
   const constraints = useFieldConstraints(inputConstraints, required);
-  const { hasError, errorMessage, value, ...inputProps } = useField(name, { constraints, disabled, type: 'checkbox' });
+  const { hasError, errorMessage, ...inputProps } = useField(name, { constraints, disabled, type: 'checkbox' });
 
   return (
-    <Switch
-      custom
-      checked={value}
-      id={name}
-      label={title}
-      {...inputProps}
-      bsCustomPrefix="custom-switch2"
-      className={className}
-    />
+    <Switch custom id={name} label={title} {...inputProps} bsCustomPrefix="custom-switch2" className={className} />
   );
 };
 

--- a/client/src/components/Form/SwitchField/styles.scss
+++ b/client/src/components/Form/SwitchField/styles.scss
@@ -12,7 +12,9 @@ $custom-control-indicator-border-color: $white-color;
 
   .custom-control-label {
     cursor: pointer;
-    line-height: $custom-switch-width / 2;
+    display: flex;
+    align-items: center;
+    height: 100%;
 
     &::before {
       cursor: pointer;
@@ -25,16 +27,23 @@ $custom-control-indicator-border-color: $white-color;
 
     &::after {
       top: $custom-control-indicator-border-width;
-      left: add(-($custom-switch-width + $custom-control-gutter), $custom-control-indicator-border-width);
+      left: calc(
+        #{$custom-control-indicator-border-width} - (#{$custom-switch-width} + #{$custom-control-gutter})
+      ) !important;
       background-color: $custom-control-indicator-border-color;
       border-radius: $custom-switch-indicator-border-radius;
+      transform: translateX($custom-switch-width / 2);
     }
   }
 
   .custom-control-input {
+    &:not(:checked) ~ .custom-control-label {
+      color: $light-gray-color;
+    }
+
     &:checked ~ .custom-control-label {
       &::after {
-        transform: translateX($custom-switch-width / 2);
+        transform: none;
       }
     }
 


### PR DESCRIPTION
## Description
- fixed styles for selected/not selected switches
- fixed paddings inside the switch
- fixed styles for label of not selected switch
- fixed styles for small size

## Screens

before:
<img width="245" alt="Screenshot 2021-03-30 at 12 14 41" src="https://user-images.githubusercontent.com/990978/112965019-8b470d00-9151-11eb-90ad-025ab85e969d.png">



after:
<img width="224" alt="Screenshot 2021-03-30 at 00 46 36" src="https://user-images.githubusercontent.com/990978/112904484-b00b9800-90f1-11eb-90a8-af2d2cdc8885.png">



in figma:
<img width="472" alt="Screenshot 2021-03-29 at 22 08 34" src="https://user-images.githubusercontent.com/990978/112887001-57310500-90db-11eb-99cd-f100458ff18f.png">
