### PR TITLE
responsive BidConfirmationModal

### DIFF
--- a/client/src/components/DialogActions/index.tsx
+++ b/client/src/components/DialogActions/index.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const DialogActions: FC<Props> = ({ children, className }) => (
-  <ModalFooter className={clsx('flex-row flex-wrap flex-sm-nowrap', className)}>{children}</ModalFooter>
+  <ModalFooter className={clsx('flex-row flex-nowrap', className)}>{children}</ModalFooter>
 );
 
 export default DialogActions;

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/BidConfirmationModal.module.scss
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/BidConfirmationModal.module.scss
@@ -1,7 +1,6 @@
 @import 'src/variables.scss';
 
 .cardInputWrapper {
-  max-width: 350px;
   margin: 0 auto;
 
   @media (max-width: $small-weight) {
@@ -9,19 +8,18 @@
   }
 }
 
-.cardInfo {
-  color: $sage-color;
+.actionBtn {
+  height: 50px !important;
+
+  @media (max-width: $small-weight) {
+    width: 100%;
+  }
+  @media (min-width: $small-weight) {
+    width: 200px;
+  }
 }
 
-.expired {
-  color: $salmon-color;
-}
-
-.addCardBtn {
-  letter-spacing: 0 !important;
-}
-
-.confirmBtn {
-  white-space: break-spaces !important;
-  height: auto;
+.newCardCancelBtn {
+  position: absolute !important;
+  right: 0;
 }

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/BidConfirmationModal.tsx
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/BidConfirmationModal.tsx
@@ -18,6 +18,7 @@ import DialogContent from 'src/components/DialogContent';
 import { UserAccountContext } from 'src/components/UserAccountProvider/UserAccountContext';
 
 import styles from './BidConfirmationModal.module.scss';
+import CardInfo from './CardInfo';
 import StripeInput from './StripeInput';
 
 export interface BidConfirmationRef {
@@ -62,6 +63,10 @@ export const BidConfirmationModal = forwardRef<BidConfirmationRef, Props>(({ auc
     setCardComplete(event.complete);
   }, []);
 
+  const handleNewCardCancelBtnClick = useCallback(() => {
+    setNewCard(false);
+  }, [setNewCard]);
+
   const handleSubmit = useCallback(async () => {
     if (!elements || !activeBid) {
       return;
@@ -102,58 +107,58 @@ export const BidConfirmationModal = forwardRef<BidConfirmationRef, Props>(({ auc
 
   useEffect(() => setNewCard(false), []);
 
-  const renderCardInfo = () => {
-    return (
-      <div className={clsx(styles.cardInfo, expired && styles.expired)}>
-        <p className="text-center mb-1">
-          {paymentInformation?.cardBrand} **** **** **** {paymentInformation?.cardNumberLast4},{' '}
-          {paymentInformation?.cardExpirationMonth}/{`${paymentInformation?.cardExpirationYear}`.slice(-2)}{' '}
-          {expired && <span className="text-all-cups font-weight-bold">expired</span>}
-        </p>
-      </div>
-    );
-  };
-
   return (
     <Dialog backdrop="static" keyboard={false} open={Boolean(activeBid)} title={title} onClose={handleClose}>
       <DialogContent>
-        <div className={styles.cardInputWrapper}>
-          <p className="text--body">
+        <div className={clsx(styles.cardInputWrapper, 'text--body')}>
+          <p>
             We need your card number in order to place your bid. Card will be charged only after auction end, in case
             your bid is winning.
           </p>
-          <p className="text--body">
-            Please make sure this card has enough available funds at time of auction finalization.
-          </p>
+          <p>Please make sure this card has enough available funds at time of auction finalization.</p>
 
-          {(expired || paymentInformation) && !newCard && renderCardInfo()}
-          {(!paymentInformation || newCard) && <StripeInput disabled={isSubmitting} onChange={handleCardInputChange} />}
+          {(expired || paymentInformation) && !newCard && (
+            <CardInfo
+              expired={expired}
+              isSubmitting={isSubmitting}
+              paymentInfo={paymentInformation}
+              onNewCardAdd={handleAddCard}
+            />
+          )}
+          {(!paymentInformation || newCard) && (
+            <StripeInput
+              disabled={isSubmitting}
+              showCancelBtn={Boolean(paymentInformation)}
+              onCancel={handleNewCardCancelBtnClick}
+              onChange={handleCardInputChange}
+            />
+          )}
+
+          <p className="text-center pt-0 pt-sm-3 mb-0">
+            Your bid is <span className="font-weight-bold">{activeBid?.toFormat('$0,0')}</span>
+          </p>
         </div>
       </DialogContent>
 
-      <DialogActions className="justify-content-center">
-        {(paymentInformation || expired) && !newCard && (
-          <Button
-            className={clsx(styles.addCardBtn, 'mx-auto text--body mt-0 pt-0 m-sm-auto p-sm-auto')}
-            disabled={isSubmitting}
-            size="sm"
-            variant="link"
-            onClick={handleAddCard}
-          >
-            Use another card
-          </Button>
-        )}
-        {(!expired || newCard) && (
-          <AsyncButton
-            className={styles.confirmBtn}
-            disabled={isSubmitting || (!paymentInformation && expired) || (newCard && !cardComplete)}
-            loading={isSubmitting}
-            variant="secondary"
-            onClick={handleSubmit}
-          >
-            Confirm bidding {activeBid?.toFormat('$0,0')}
-          </AsyncButton>
-        )}
+      <DialogActions className="justify-content-center flex-column-reverse flex-sm-row pt-0 pt-sm-2">
+        <Button
+          className={clsx(styles.actionBtn, 'ml-0 mr-sm-auto p-3')}
+          size="sm"
+          variant="light"
+          onClick={handleClose}
+        >
+          Cancel
+        </Button>
+
+        <AsyncButton
+          className={styles.actionBtn}
+          disabled={isSubmitting || expired || ((newCard || !paymentInformation) && !cardComplete)}
+          loading={isSubmitting}
+          variant="secondary"
+          onClick={handleSubmit}
+        >
+          Confirm bidding
+        </AsyncButton>
       </DialogActions>
     </Dialog>
   );

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/CardInfo/index.tsx
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/CardInfo/index.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react';
+
+import clsx from 'clsx';
+import { Button } from 'react-bootstrap';
+
+import { PaymentInformation } from 'src/components/UserAccountProvider/PaymentInformation';
+
+import styles from './styles.module.scss';
+
+export interface BidConfirmationRef {
+  placeBid: (amount: Dinero.Dinero) => void;
+}
+
+interface Props {
+  expired: boolean;
+  isSubmitting: boolean;
+  paymentInfo: PaymentInformation | null | undefined;
+  onNewCardAdd: () => void;
+}
+
+const CardInfo: FC<Props> = ({ expired, isSubmitting, paymentInfo, onNewCardAdd }) => {
+  if (!paymentInfo) {
+    return null;
+  }
+
+  return (
+    <div className={clsx(styles.cardInfo, expired && styles.expired, 'flex-wrap')}>
+      <div className="flex-column text-center">
+        {paymentInfo.cardBrand} **** **** **** {paymentInfo.cardNumberLast4}, {paymentInfo.cardExpirationMonth}/
+        {`${paymentInfo.cardExpirationYear}`.slice(-2)}{' '}
+        {expired && <span className="text-all-cups font-weight-bold">expired</span>}
+      </div>
+
+      <Button
+        className={clsx(styles.addCardBtn, 'text--body flex-column')}
+        disabled={isSubmitting}
+        size="sm"
+        variant="link"
+        onClick={onNewCardAdd}
+      >
+        Use another card
+      </Button>
+    </div>
+  );
+};
+
+export default CardInfo;

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/CardInfo/styles.module.scss
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/CardInfo/styles.module.scss
@@ -1,0 +1,21 @@
+@import 'src/variables.scss';
+
+.cardInfo {
+  color: $sage-color;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 61px;
+
+  @media (min-width: $small-weight) {
+    height: 38px;
+  }
+}
+
+.expired {
+  color: $salmon-color;
+}
+
+.addCardBtn {
+  letter-spacing: 0 !important;
+}

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/StripeInput/index.tsx
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/StripeInput/index.tsx
@@ -3,15 +3,18 @@ import React, { FC, useMemo, useState } from 'react';
 import { CardElement } from '@stripe/react-stripe-js';
 import type { StripeCardElementChangeEvent, StripeCardElement } from '@stripe/stripe-js';
 import clsx from 'clsx';
+import { Button } from 'react-bootstrap';
 
 import styles from './styles.module.scss';
 
 interface Props {
   disabled: boolean;
+  showCancelBtn: boolean;
   onChange?(event: StripeCardElementChangeEvent): void;
+  onCancel: () => void;
 }
 
-const StripeInput: FC<Props> = ({ disabled, onChange }) => {
+const StripeInput: FC<Props> = ({ disabled, onChange, onCancel, showCancelBtn }) => {
   const [node, setNode] = useState<StripeCardElement | null>(null);
   const [focused, setFocused] = useState(false);
 
@@ -32,7 +35,6 @@ const StripeInput: FC<Props> = ({ disabled, onChange }) => {
 
         invalid: {
           color: '#e1825f',
-
           '::placeholder': {
             color: '#caccc6',
           },
@@ -43,7 +45,7 @@ const StripeInput: FC<Props> = ({ disabled, onChange }) => {
   );
 
   return (
-    <div className={clsx(styles.root, focused && styles.focused)} onClick={() => node?.focus()}>
+    <div className={clsx(styles.root, 'mb-4 mb-sm-0', focused && styles.focused)} onClick={() => node?.focus()}>
       <CardElement
         options={options}
         onBlur={() => setFocused(false)}
@@ -51,6 +53,11 @@ const StripeInput: FC<Props> = ({ disabled, onChange }) => {
         onFocus={() => setFocused(true)}
         onReady={setNode}
       />
+      {showCancelBtn && (
+        <Button className={clsx(styles.newCardCancelBtn, 'pr-0')} size="sm" variant="link" onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
     </div>
   );
 };

--- a/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/StripeInput/styles.module.scss
+++ b/client/src/modules/auctions/AuctionPage/AuctionDetails/BidConfirmationModal/StripeInput/styles.module.scss
@@ -13,3 +13,13 @@
   box-shadow: inset 0 0 0 1px $sage-color;
   border-color: $sage-color;
 }
+
+.newCardCancelBtn {
+  position: absolute !important;
+  right: 0;
+  top: 35px;
+
+  @media (max-width: $small-weight) {
+    top: 30px;
+  }
+}

--- a/client/src/overrideStyles/_buttons.scss
+++ b/client/src/overrideStyles/_buttons.scss
@@ -5,6 +5,11 @@
   align-items: center;
   justify-content: center;
   letter-spacing: 0.1em;
+  border-radius: 10px;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 
   &.btn-secondary {
     color: $sage-color;


### PR DESCRIPTION
## Description
make Bid Confirmation Modal responsive
added cancel button for new card input

## Screens
before:
<img width="570" alt="Screenshot 2021-03-30 at 17 01 23" src="https://user-images.githubusercontent.com/990978/113005990-a3348600-917d-11eb-96c1-1048d205c8bd.png">
<img width="270" alt="Screenshot 2021-03-30 at 17 01 38" src="https://user-images.githubusercontent.com/990978/113005999-a4fe4980-917d-11eb-9a21-037abc9b9c45.png">

after:
mobile:
<img width="336" alt="Screenshot 2021-03-31 at 01 46 25" src="https://user-images.githubusercontent.com/990978/113066417-2a581d00-91c3-11eb-9065-84d00503eb09.png">
<img width="336" alt="Screenshot 2021-03-31 at 01 46 31" src="https://user-images.githubusercontent.com/990978/113066422-2b894a00-91c3-11eb-847c-a8aa638b8370.png">



tablet:
<img width="519" alt="Screenshot 2021-03-31 at 01 45 55" src="https://user-images.githubusercontent.com/990978/113066393-21674b80-91c3-11eb-9781-1c34962df1e7.png">
<img width="518" alt="Screenshot 2021-03-31 at 01 46 06" src="https://user-images.githubusercontent.com/990978/113066396-22987880-91c3-11eb-8a0a-77801e9635fe.png">


desktop
<img width="520" alt="Screenshot 2021-03-31 at 01 45 36" src="https://user-images.githubusercontent.com/990978/113066373-18767a00-91c3-11eb-9b71-d2c96825425d.png">
<img width="519" alt="Screenshot 2021-03-31 at 01 45 43" src="https://user-images.githubusercontent.com/990978/113066376-19a7a700-91c3-11eb-9aac-045807d66548.png">
