### PR TITLE
add possibility to add multiple accounts to single phone number

### DIFF
--- a/server/app/Invitation/service/InvitationService.ts
+++ b/server/app/Invitation/service/InvitationService.ts
@@ -109,7 +109,7 @@ export class InvitationService {
     let influencerProfile: InfluencerProfile = null;
 
     try {
-      const { firstName, lastName, phoneNumber, welcomeMessage } = input;
+      const { firstName, lastName, phoneNumber, welcomeMessage, influencerId } = input;
 
       await session.withTransaction(async () => {
         const userAccount = await this.userAccountService.getAccountByPhoneNumber(phoneNumber, session);
@@ -128,7 +128,7 @@ export class InvitationService {
           await this.twilioNotificationService.sendMessage(phoneNumber, message);
           await this.eventHub.broadcast(Events.INFLUENCER_ONBOARDED, { userAccount, influencerProfile });
         } else {
-          if (await this.InvitationModel.exists({ phoneNumber })) {
+          if (await this.InvitationModel.exists({ parentEntityId: influencerId })) {
             throw new AppError(`Invitation to ${phoneNumber} has already been sent`, ErrorCode.BAD_REQUEST);
           }
           const invitation = await this.createInfluencerInvitation(

--- a/server/app/UserAccount/mongodb/UserAccountModel.ts
+++ b/server/app/UserAccount/mongodb/UserAccountModel.ts
@@ -14,7 +14,7 @@ export const UserAccountCollectionName = 'account';
 
 const UserAccountSchema: Schema<IUserAccount> = new Schema<IUserAccount>({
   authzId: { type: SchemaTypes.String, required: true, index: true, unique: true },
-  phoneNumber: { type: SchemaTypes.String, required: true, unique: true },
+  phoneNumber: { type: SchemaTypes.String, required: true },
   isAdmin: { type: SchemaTypes.Boolean, required: false },
   stripeCustomerId: { type: SchemaTypes.String, required: false },
   createdAt: { type: SchemaTypes.Date, required: true },

--- a/server/app/UserAccount/service/UserAccountService.ts
+++ b/server/app/UserAccount/service/UserAccountService.ts
@@ -72,10 +72,6 @@ export class UserAccountService {
       throw new AppError('Account already exists', ErrorCode.BAD_REQUEST);
     }
 
-    if (await this.accountModel.findOne({ phoneNumber }).exec()) {
-      throw new AppError(`${phoneNumber} is already in use`, ErrorCode.BAD_REQUEST);
-    }
-
     const accountModel = await this.accountModel.create({ authzId, phoneNumber, createdAt: dayjs().toISOString() });
     const account = UserAccountService.makeUserAccount(accountModel);
 


### PR DESCRIPTION
### Until all points which are described are not resolved, it's not recommended to merge this PR

Points to resolve:
* As far as I saw in `InvitationService.ts` there is a method to invite assistant, and `influencerId` key is optional and we search for the assistant only by phone number. Proposal: Make that field required and pass it down to the server from the UI
* To make it work in prod env, we have to drop `phoneNumber` index inside the mongodb database via - `db.accounts.dropIndex('phoneNumber_1')`
* Quick reaction required ASAP!

