### PR TITLE
UI fixes

### DIFF
--- a/client/src/components/modals/AttachmentModal/index.tsx
+++ b/client/src/components/modals/AttachmentModal/index.tsx
@@ -21,7 +21,7 @@ const AttachmentModal: FC<Props> = ({ attachment, closeModal }) => {
   return (
     <Modal
       centered
-      contentClassName={clsx('d-table', isVideo || 'w-auto')}
+      contentClassName={clsx('d-table pt-4', isVideo || 'w-auto')}
       dialogClassName={styles.modal}
       show={true}
       onHide={closeModal}

--- a/client/src/components/modals/AttachmentModal/styles.module.scss
+++ b/client/src/components/modals/AttachmentModal/styles.module.scss
@@ -27,7 +27,6 @@
 .closeBtn {
   position: absolute;
   right: 20px;
-  top: 20px;
   border: none;
   background-color: $white-color;
   color: $dark-sage-color;

--- a/client/src/modules/auctions/AuctionPage/AttachmentsSlider/styles.module.scss
+++ b/client/src/modules/auctions/AuctionPage/AttachmentsSlider/styles.module.scss
@@ -58,9 +58,6 @@
 }
 
 @media (min-width: $extra-large-weight) {
-  .slider {
-    flex-direction: row-reverse;
-  }
   .attachmentImageWrapper {
     border: 1px solid $whitesmoke-color;
   }


### PR DESCRIPTION
fixed:
* broken styles for attachments for closed auctions
* styles for attachments modals:
<img width="615" alt="Screenshot 2022-03-14 at 16 49 30" src="https://user-images.githubusercontent.com/990978/158185808-029e9102-1014-4b68-9246-876b61eb8fa7.png">
![Uploading Screenshot 2022-03-14 at 16.49.14.png…]()

