### PR TITLE
fix attachment slider not displaying image/video when only 1 attachment in list

### DIFF
--- a/client/src/modules/auctions/AuctionPage/AttachmentsSlider/index.tsx
+++ b/client/src/modules/auctions/AuctionPage/AttachmentsSlider/index.tsx
@@ -40,7 +40,11 @@ const AttachmentsSlider: FC<Props> = ({ attachments }): ReactElement | null => {
   const settings = {
     arrows: false,
     dots: true,
-    className: clsx(styles.slider, 'auction-attachments-slider text-center'),
+    className: clsx(
+      styles.slider,
+      `
+      auction-attachments-slider text-center ${attachments.length === 1 && styles.flexDirectionOverride}`,
+    ),
     customPaging: desktopPaging,
     slidesToShow: 1,
     slidesToScroll: 1,

--- a/client/src/modules/auctions/AuctionPage/AttachmentsSlider/styles.module.scss
+++ b/client/src/modules/auctions/AuctionPage/AttachmentsSlider/styles.module.scss
@@ -61,6 +61,9 @@
   .slider {
     flex-direction: row-reverse;
   }
+  .flexDirectionOverride {
+    flex-direction: column !important;
+  }
   .attachmentImageWrapper {
     border: 1px solid $whitesmoke-color;
   }


### PR DESCRIPTION
override flex-direction row-reverse when slick slider only has 1 attachment thumbnail