### PR TITLE
TermsConfirmationDialog logic fix

### DIFF
--- a/client/src/components/modals/AdminAuctionsPageModal/index.tsx
+++ b/client/src/components/modals/AdminAuctionsPageModal/index.tsx
@@ -36,7 +36,7 @@ export const Modal: FC<Props> = ({ open, onClose, onConfirm, mutation, auction }
   }, [deleteAuction, auction, onConfirm, onClose]);
 
   return (
-    <Dialog className="fw-normal text-center" open={open} title="Confirm deleting" onClose={onClose}>
+    <Dialog classNameHeader="fw-normal text-center" open={open} title="Confirm deleting" onClose={onClose}>
       <DialogContent>
         Do you want to delete an auction: <b>{auction.title}</b>?
       </DialogContent>

--- a/client/src/components/modals/Dialog/index.tsx
+++ b/client/src/components/modals/Dialog/index.tsx
@@ -6,6 +6,7 @@ const { Header, Title } = Modal;
 
 interface Props extends ModalProps {
   className?: string;
+  classNameHeader?: string;
   open: boolean;
   onClose: () => void;
   title?: string;
@@ -13,11 +14,29 @@ interface Props extends ModalProps {
   withCloseButton?: boolean;
 }
 
-const Dialog: FC<Props> = ({ className, open, onClose, title, children, size, withCloseButton, ...rest }) => {
+const Dialog: FC<Props> = ({
+  className,
+  classNameHeader,
+  open,
+  onClose,
+  title,
+  children,
+  size,
+  withCloseButton,
+  ...rest
+}) => {
   return (
-    <Modal centered aria-labelledby="contained-modal" show={open} size={size} onHide={onClose} {...rest}>
+    <Modal
+      centered
+      aria-labelledby="contained-modal"
+      className={className}
+      show={open}
+      size={size}
+      onHide={onClose}
+      {...rest}
+    >
       {title && (
-        <Header className={className} closeButton={withCloseButton ?? true}>
+        <Header className={classNameHeader} closeButton={withCloseButton ?? true}>
           <Title id="contained-modal">{title}</Title>
         </Header>
       )}

--- a/client/src/components/modals/TermsConfirmationDialog/__tests__/TermsConfirmationDialog.test.tsx
+++ b/client/src/components/modals/TermsConfirmationDialog/__tests__/TermsConfirmationDialog.test.tsx
@@ -1,8 +1,9 @@
 import { act } from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, BrowserRouter as Router } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { ToastProvider } from 'react-toast-notifications';
+import { waitFor } from '@testing-library/react';
 
 import Form from 'src/components/forms/Form/Form';
 import { testAccount } from 'src/helpers/testHelpers/account';
@@ -10,18 +11,21 @@ import { AcceptAccountTermsMutation } from 'src/apollo/queries/terms';
 import TermsConfirmationDialog from 'src/components/modals/TermsConfirmationDialog';
 import { UserAccountContext } from 'src/components/helpers/UserAccountProvider/UserAccountContext';
 
-let assignMock = jest.fn();
-
-delete window.location;
-window.location = { assign: assignMock };
-
 describe('TermsConfirmationDialog', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  const assignMock = jest.fn();
+  let wrapper: ReactWrapper;
+  const oldWindowLocation = window.location;
+
+  beforeAll(() => {
+    delete window.location;
+    window.location = { ...oldWindowLocation, assign: jest.fn() };
+  });
+
+  afterAll(() => {
+    window.location = oldWindowLocation;
   });
 
   const mockFn = jest.fn();
-
   const mocks = [
     {
       request: {
@@ -43,75 +47,112 @@ describe('TermsConfirmationDialog', () => {
     },
   ];
 
-  const testAccountWithDiff = { account: { ...testAccount.account, notAcceptedTerms: '1.0' } };
-  it('should return null', () => {
-    let wrapper: ReactWrapper;
-    wrapper = mount(
-      <MemoryRouter>
-        <ToastProvider>
-          <MockedProvider>
-            <UserAccountContext.Provider value={testAccount}>
-              <TermsConfirmationDialog />
-            </UserAccountContext.Provider>
-          </MockedProvider>
-        </ToastProvider>
-      </MemoryRouter>,
-    );
-    expect(wrapper.find('Dialog')).toHaveLength(0);
-  });
-  it('component is defined', () => {
-    let wrapper: ReactWrapper;
-    wrapper = mount(
-      <MemoryRouter>
-        <ToastProvider>
-          <MockedProvider>
-            <UserAccountContext.Provider value={testAccountWithDiff}>
-              <TermsConfirmationDialog />
-            </UserAccountContext.Provider>
-          </MockedProvider>
-        </ToastProvider>
-      </MemoryRouter>,
-    );
-    expect(wrapper.find('Dialog')).toHaveLength(1);
-  });
-  it('should submit form and not call the mutation becouse of false submit values', async () => {
-    let wrapper: ReactWrapper;
+  describe('when the user have accepted terms already', () => {
+    it('should return null', async () => {
+      await act(async () => {
+        wrapper = mount(
+          <MemoryRouter>
+            <ToastProvider>
+              <MockedProvider>
+                <UserAccountContext.Provider value={testAccount}>
+                  <TermsConfirmationDialog />
+                </UserAccountContext.Provider>
+              </MockedProvider>
+            </ToastProvider>
+          </MemoryRouter>,
+        );
 
-    wrapper = mount(
-      <MemoryRouter>
-        <ToastProvider>
-          <MockedProvider mocks={mocks}>
-            <UserAccountContext.Provider value={testAccountWithDiff}>
-              <TermsConfirmationDialog />
-            </UserAccountContext.Provider>
-          </MockedProvider>
-        </ToastProvider>
-      </MemoryRouter>,
-    );
+        await new Promise((r) => setTimeout(r, 10));
+        wrapper.update();
 
-    await act(async () => {
-      wrapper.find(Form).props().onSubmit({ terms: false });
+        expect(wrapper.find('Dialog')).toHaveLength(0);
+      });
     });
-    expect(mockFn).toHaveBeenCalledTimes(0);
   });
-  it('should submit form and call the mutation', async () => {
-    let wrapper: ReactWrapper;
-    await act(async () => {
-      wrapper = mount(
-        <MemoryRouter>
+
+  describe('when the user has not accepted terms', () => {
+    const accountWithNotAcceptedTerms = { account: { ...testAccount.account, notAcceptedTerms: '1.0' } };
+
+    it('component is defined', async () => {
+      await act(async () => {
+        global.fetch = jest.fn(async () => ({
+          text: async () => 'test text',
+        }));
+
+        wrapper = mount(
+          <MemoryRouter>
+            <ToastProvider>
+              <MockedProvider>
+                <UserAccountContext.Provider value={accountWithNotAcceptedTerms}>
+                  <TermsConfirmationDialog />
+                </UserAccountContext.Provider>
+              </MockedProvider>
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+
+        await new Promise((r) => setTimeout(r, 10));
+        wrapper.update();
+
+        expect(wrapper.find('Dialog')).toHaveLength(1);
+      });
+    });
+
+    it('does submit form when the user did not accept the terms', async () => {
+      await act(async () => {
+        global.fetch = jest.fn(async () => ({
+          text: async () => 'test text',
+        }));
+
+        wrapper = mount(
+          <MemoryRouter>
+            <ToastProvider>
+              <MockedProvider mocks={mocks}>
+                <Router>
+                  <UserAccountContext.Provider value={accountWithNotAcceptedTerms}>
+                    <TermsConfirmationDialog />
+                  </UserAccountContext.Provider>
+                </Router>
+              </MockedProvider>
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+
+        await new Promise((r) => setTimeout(r, 10));
+        wrapper.update();
+
+        await act(async () => {
+          wrapper.find(Form).props().onSubmit({ terms: false });
+        });
+        expect(mockFn).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it('submits form when the user accepted the terms', async () => {
+      await act(async () => {
+        global.fetch = jest.fn(async () => ({
+          text: async () => 'test text',
+        }));
+
+        wrapper = mount(
           <ToastProvider>
             <MockedProvider mocks={mocks}>
-              <UserAccountContext.Provider value={testAccountWithDiff}>
-                <TermsConfirmationDialog />
-              </UserAccountContext.Provider>
+              <Router>
+                <UserAccountContext.Provider value={accountWithNotAcceptedTerms}>
+                  <TermsConfirmationDialog />
+                </UserAccountContext.Provider>
+              </Router>
             </MockedProvider>
-          </ToastProvider>
-        </MemoryRouter>,
-      );
+          </ToastProvider>,
+        );
+        await new Promise((r) => setTimeout(r, 10));
+        wrapper.update();
+
+        await act(async () => {
+          wrapper.find(Form).props().onSubmit({ terms: true });
+        });
+        expect(mockFn).toHaveBeenCalledTimes(1);
+      });
     });
-    await act(async () => {
-      wrapper.find(Form).props().onSubmit({ terms: true });
-    });
-    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/modules/UserProfile/ProfileInformation/Modal/index.tsx
+++ b/client/src/modules/UserProfile/ProfileInformation/Modal/index.tsx
@@ -25,7 +25,7 @@ const Modal: FC<Props> = ({ currentPhoneNumber, showDialog, setCloseDialog, setP
   }, [setCloseDialog]);
 
   return (
-    <Dialog className="p-4" open={showDialog} title="Confirm Number" onClose={onClose}>
+    <Dialog classNameHeader="p-4" open={showDialog} title="Confirm Number" onClose={onClose}>
       <DialogContent className={styles.content}>
         {verified ? (
           <ConfirmationStep

--- a/client/src/modules/admin/auctions/AdminAuctionPage/Modal/index.tsx
+++ b/client/src/modules/admin/auctions/AdminAuctionPage/Modal/index.tsx
@@ -37,7 +37,12 @@ export const Modal: FC<Props> = ({
   const { bid, user } = currentBid;
 
   return (
-    <Dialog className="fw-normal text-left" open={open} title={`Charge ${isBid ? 'bid' : 'auction'}`} onClose={onClose}>
+    <Dialog
+      classNameHeader="fw-normal text-left"
+      open={open}
+      title={`Charge ${isBid ? 'bid' : 'auction'}`}
+      onClose={onClose}
+    >
       <DialogContent className="text-center pt-0">
         <p>
           Withdraw <b>${bid?.amount / 100}</b>

--- a/client/src/modules/admin/auctions/AdminAuctionsPage/EditDeliveryParcelButton/Modal/index.tsx
+++ b/client/src/modules/admin/auctions/AdminAuctionsPage/EditDeliveryParcelButton/Modal/index.tsx
@@ -71,7 +71,13 @@ export const Modal: FC<Props> = ({ open, onClose, mutation, auction, getAuctions
   );
 
   return (
-    <Dialog className="fw-normal text-center" open={open} size="sm" title="Delivery box properties" onClose={onClose}>
+    <Dialog
+      classNameHeader="fw-normal text-center"
+      open={open}
+      size="sm"
+      title="Delivery box properties"
+      onClose={onClose}
+    >
       <Form initialValues={currentValues} onSubmit={onSubmit}>
         <DialogContent>
           <ModalRow title="Length in">

--- a/client/src/modules/charity/CharityProfilePage/ShareBtn/Modal/index.tsx
+++ b/client/src/modules/charity/CharityProfilePage/ShareBtn/Modal/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const QRCodeModal: FC<Props> = ({ name, src, open, onClose }) => {
   return (
-    <Dialog className="pb-0" open={open} title={`Share Charity: ${name}`} onClose={onClose}>
+    <Dialog classNameHeader="pb-0" open={open} title={`Share Charity: ${name}`} onClose={onClose}>
       <DialogContent className="p-0">
         <img alt="qr code" className="mx-auto d-block w-100 h-100" src={src} />
       </DialogContent>


### PR DESCRIPTION
### issue:

when not logged in user is trying to make a bid, we redirect him to log in page first, and then display a bid modal.
we display terms confirmation modal also for new user.
So, if not registered user will try to make a bid, we will display two modals after registration and the bid modal will be on the front.

### Solution:
display  terms confirmation modal first.

<img width="1066" alt="Screenshot 2022-04-19 at 00 34 47" src="https://user-images.githubusercontent.com/990978/163996048-55a47a77-490e-4510-8951-b1440ecf1b44.png">
