### PR TITLE
styling updates on auction ended cards

### DIFF
--- a/client/src/components/custom/AuctionCard/index.tsx
+++ b/client/src/components/custom/AuctionCard/index.tsx
@@ -125,7 +125,7 @@ const AuctionCard: FC<Props> = ({ auction, auctionOrganizer, isDonePage, onDelet
         </SwipeableLink>
       </div>
 
-      <figcaption className={clsx(styles.description, 'd-flex flex-column p-3')}>
+      <figcaption className={clsx(styles.description, isSettled && styles.settled, 'd-flex flex-column p-3')}>
         <SwipeableLink className={clsx(styles.title, 'mb-4 text-label-new')} title={auction.title} to={linkToAuction}>
           {auction.title}
         </SwipeableLink>

--- a/client/src/components/custom/AuctionCard/styles.module.scss
+++ b/client/src/components/custom/AuctionCard/styles.module.scss
@@ -37,7 +37,7 @@
 }
 
 .settled {
-  opacity: 0.3;
+  opacity: 0.2;
 }
 
 .deleteBtn {
@@ -58,11 +58,16 @@
 
 .statusLabel {
   top: 1rem;
-  left: 1rem;
+  right: 1rem;
   position: absolute;
-  color: $white-color;
-  background-color: $gray-color;
+  border: 1px solid $dark-gray-color;
+  color: $dark-gray-color;
+  background-color: $white-color;
   padding: 4px 6px;
+  border-radius: 8px;
+  z-index: 2;
+  font-weight: 500;
+  font-size: 11px;
 }
 
 @media (max-width: $medium-weight) {


### PR DESCRIPTION
Before:
<img width="250" alt="Screen Shot 2022-06-26 at 10 12 37 AM" src="https://user-images.githubusercontent.com/1562521/175825842-cf2bcec7-ca6f-4007-a217-4e948a142c75.png">
After:
<img width="250" alt="Screen Shot 2022-06-26 at 10 12 49 AM" src="https://user-images.githubusercontent.com/1562521/175825855-72d5e106-c056-4429-9046-0f62c3feb5cc.png">

